### PR TITLE
Structural changes to messages

### DIFF
--- a/scenarios/NCH-1.md
+++ b/scenarios/NCH-1.md
@@ -120,21 +120,21 @@ _(2 specimen received messages)_
 {
   "header": {
     "msg_guid": "5c64192f-8a25-4874-9db6-fd55c398822d",
-    "msg_dttm": "2016-04-25T18:42:13+00:00"
+    "msg_dttm": "2016-04-25T18:42:13Z"
   },
   "specimen_received": {
     "study_id": "APEC1621",
     "patient_id": "894561",
     "type": "BLOOD",
-    "collection_dttm": "2016-04-25T14:17:11+00:00",
-    "received_dttm": "2016-04-25T15:17:11+00:00",
-    "internal_use_only": {
-      "stars_patient_id": "ABCXYZ",
-      "stars_specimen_id": "ABCXYZ-0AK64L",
-      "stars_specimen_type": "Blood Fresh",
-      "received_dttm": "2016-04-25T15:17:11+00:00",
-      "qc_dttm": "2016-04-25T16:21:34+00:00"
-    }
+    "collection_dt": "2016-04-25",
+    "received_dttm": "2016-04-25T12:34:56Z"
+  },
+  "internal_use_only": {
+    "stars_patient_id": "ABCXYZ",
+    "stars_specimen_id": "ABCXYZ-0AK64L",
+    "stars_specimen_type": "Blood Fresh",
+    "received_dttm": "2016-04-25T12:34:56Z",
+    "qc_dttm": "2016-04-25T13:45:56Z"
   }
 }
 ```
@@ -143,22 +143,22 @@ _(2 specimen received messages)_
 {
   "header": {
     "msg_guid": "ab6d8d37-caf2-4dbb-a360-0032c7a7a76c",
-    "msg_dttm": "2016-04-25T18:42:13+00:00"
+    "msg_dttm": "2016-04-25T18:42:13Z"
   },
   "specimen_received": {
     "study_id": "APEC1621",
     "patient_id": "894561",
     "type": "TISSUE",
     "surgical_event_id": "125", 
-    "collection_dttm": "2016-04-25T14:17:11+00:00",
-    "received_dttm": "2016-04-25T15:17:11+00:00",
-    "internal_use_only": {
-      "stars_patient_id": "ABCXYZ",
-      "stars_specimen_id": "ABCXYZ-0AK64M",
-      "stars_specimen_type": "Paraffin Block Primary",
-      "received_dttm": "2016-04-25T15:17:11+00:00",
-      "qc_dttm": "2016-04-25T16:21:34+00:00"
-    }
+    "collection_dt": "2016-04-25",
+    "received_dttm": "2016-04-25T15:17:11Z"
+  },
+  "internal_use_only": {
+    "stars_patient_id": "ABCXYZ",
+    "stars_specimen_id": "ABCXYZ-0AK64M",
+    "stars_specimen_type": "Paraffin Block Primary",
+    "received_dttm": "2016-04-25T15:17:11Z",
+    "qc_dttm": "2016-04-25T16:21:34Z"
   }
 }
 ```
@@ -170,7 +170,7 @@ _(5 specimen shipped messages)_
 {
   "header": {
     "msg_guid": "7912901b-7285-40cc-9269-1cae961a0ea7",
-    "msg_dttm": "2016-05-01T19:42:13+00:00"
+    "msg_dttm": "2016-05-01T19:42:13Z"
   },
   "specimen_shipped": {
     "study_id": "APEC1621",
@@ -180,13 +180,13 @@ _(5 specimen shipped messages)_
     "destination": "MDA",
     "carrier": "Federal Express",
     "tracking_id": "7956 4568 1235",
-    "shipped_dttm": "2016-05-01T19:42:13+00:00",
+    "shipped_dttm": "2016-05-01T19:42:13Z",
     "dna_volume_ul": 10,
-    "dna_concentration_ng_per_ul": 25,
-    "internal_use_only": {
-      "stars_patient_id": "ABCXYZ",
-      "stars_specimen_id": "ABCXYZ-0BJ64A"
-    }
+    "dna_concentration_ng_per_ul": 25
+  },
+  "internal_use_only": {
+    "stars_patient_id": "ABCXYZ",
+    "stars_specimen_id": "ABCXYZ-0BJ64A"
   }
 }
 ```
@@ -195,7 +195,7 @@ _(5 specimen shipped messages)_
 {
   "header": {
     "msg_guid": "3037ddec-0081-4e22-8448-721ab4ad76b4",
-    "msg_dttm": "2016-05-01T19:42:13+00:00"
+    "msg_dttm": "2016-05-01T19:42:13Z"
   },
   "specimen_shipped": {
     "study_id": "APEC1621",
@@ -206,15 +206,15 @@ _(5 specimen shipped messages)_
     "destination": "MDA",
     "carrier": "Federal Express",
     "tracking_id": "7956 4568 1235",
-    "shipped_dttm": "2016-05-01T19:42:13+00:00",
+    "shipped_dttm": "2016-05-01T19:42:13Z",
     "dna_volume_ul": 10,
     "dna_concentration_ng_per_ul": 25,
-    "cdna_volume_ul": 10,
-    "internal_use_only": {
-      "stars_patient_id": "ABCXYZ",
-      "stars_specimen_id_dna": "ABCXYZ-0BJ64B",
-      "stars_specimen_id_cdna": "ABCXYZ-0BJ64F"
-    }
+    "cdna_volume_ul": 10
+  },
+  "internal_use_only": {
+    "stars_patient_id": "ABCXYZ",
+    "stars_specimen_id_dna": "ABCXYZ-0BJ64B",
+    "stars_specimen_id_cdna": "ABCXYZ-0BJ64F"
   }
 }
 ```
@@ -223,7 +223,7 @@ _(5 specimen shipped messages)_
 {
   "header": {
     "msg_guid": "37c491ec-d91a-4e95-a0cf-291dadf60b2f",
-    "msg_dttm": "2016-05-02T18:30:17+00:00"
+    "msg_dttm": "2016-05-02T18:30:17Z"
   },
   "specimen_shipped": {
     "study_id": "APEC1621",
@@ -234,11 +234,11 @@ _(5 specimen shipped messages)_
     "destination": "MDA",
     "carrier": "Federal Express",
     "tracking_id": "1234 1234 1234",
-    "shipped_dttm": "2016-05-02T18:30:17+00:00",
-    "internal_use_only": {
-      "stars_patient_id": "ABCXYZ",
-      "stars_specimen_id": "ABCXYZ-0BJ6A5"
-    }
+    "shipped_dttm": "2016-05-02T18:30:17Z"
+  },
+  "internal_use_only": {
+    "stars_patient_id": "ABCXYZ",
+    "stars_specimen_id": "ABCXYZ-0BJ6A5"
   }
 }
 ```
@@ -247,7 +247,7 @@ _(5 specimen shipped messages)_
 {
   "header": {
     "msg_guid": "0cbfe261-293b-4ef2-ade6-eec2e342bb57",
-    "msg_dttm": "2016-05-02T18:30:17+00:00"
+    "msg_dttm": "2016-05-02T18:30:17Z"
   },
   "specimen_shipped": {
     "study_id": "APEC1621",
@@ -258,11 +258,11 @@ _(5 specimen shipped messages)_
     "destination": "MDA",
     "carrier": "Federal Express",
     "tracking_id": "1234 1234 1234",
-    "shipped_dttm": "2016-05-02T18:30:17+00:00",
-    "internal_use_only": {
-      "stars_patient_id": "ABCXYZ",
-      "stars_specimen_id": "ABCXYZ-0BJ6A6"
-    }
+    "shipped_dttm": "2016-05-02T18:30:17Z"
+  },
+  "internal_use_only": {
+    "stars_patient_id": "ABCXYZ",
+    "stars_specimen_id": "ABCXYZ-0BJ6A6"
   }
 }
 ```
@@ -271,7 +271,7 @@ _(5 specimen shipped messages)_
 {
   "header": {
     "msg_guid": "5c5f38ea-c2b4-4519-b252-82d8b8043975",
-    "msg_dttm": "2016-05-02T18:30:17+00:00"
+    "msg_dttm": "2016-05-02T18:30:17Z"
   },
   "specimen_shipped": {
     "study_id": "APEC1621",
@@ -282,11 +282,11 @@ _(5 specimen shipped messages)_
     "destination": "MDA",
     "carrier": "Federal Express",
     "tracking_id": "1234 1234 1234",
-    "shipped_dttm": "2016-05-02T18:30:17+00:00",
-    "internal_use_only": {
-      "stars_patient_id": "ABCXYZ",
-      "stars_specimen_id": "ABCXYZ-0BJ6A7"
-    }
+    "shipped_dttm": "2016-05-02T18:30:17Z",
+  },
+  "internal_use_only": {
+    "stars_patient_id": "ABCXYZ",
+    "stars_specimen_id": "ABCXYZ-0BJ6A7"
   }
 }
 ```


### PR DESCRIPTION
- Promoted the "internal_use_only" structure up to the top level (peer of "header" and "specimen_shipped" (etc.))
- Changed collection_dttm data format from date/time to date and renamed to collection_dt
- Changed formatting of all date/times to use ISO-8601 format with "Z" suffix instead of hour offset
